### PR TITLE
Recognize trailing quotes in triple-quote strings

### DIFF
--- a/Syntaxes/Scala.tmLanguage
+++ b/Syntaxes/Scala.tmLanguage
@@ -558,7 +558,7 @@
 					<key>begin</key>
 					<string>"""</string>
 					<key>end</key>
-					<string>"""</string>
+					<string>"""(?!")</string>
 					<key>name</key>
 					<string>string.quoted.triple.scala</string>
 				</dict>


### PR DESCRIPTION
If a triple-quoted string ends with more than 3 quote characters, all prepending quote characters should be interpreted as contents of the string.

For more info, see [this forum thread](http://www.sublimetext.com/forum/viewtopic.php?f=3&t=2707). (The bug was discovered in Sublime Text, but also applies to TextMate).
