### PR TITLE
Match scala symbols composed of valid punctuation

### DIFF
--- a/Syntaxes/Scala.tmLanguage
+++ b/Syntaxes/Scala.tmLanguage
@@ -792,7 +792,7 @@
 		<key>scala-symbol</key>
 		<dict>
 			<key>match</key>
-			<string>('\w+(?=[^'\w])|'[\/*&^%#@!~<>|=+-]+(?=[^'\/*&^%#@!~<>|=+-]))</string>
+			<string>('\w+(?=[^'\w])|'[-?~&gt;&lt;^+*%:!#|/@\\]+(?=[-?~&gt;&lt;^+*%:!#|/@\\]))</string>
 			<key>name</key>
 			<string>entity.name.type.symbol.scala</string>
 		</dict>

--- a/Syntaxes/Scala.tmLanguage
+++ b/Syntaxes/Scala.tmLanguage
@@ -792,7 +792,7 @@
 		<key>scala-symbol</key>
 		<dict>
 			<key>match</key>
-			<string>'\w+(?=[^'\w])</string>
+			<string>('\w+(?=[^'\w])|'[\/*&^%#@!~<>|=+-]+(?=[^'\/*&^%#@!~<>|=+-]))</string>
 			<key>name</key>
 			<string>entity.name.type.symbol.scala</string>
 		</dict>


### PR DESCRIPTION
Scala symbols can either be composed of word characters or punctuation characters when using the `'` operator. The punctuation characters added in this PR are not the full set allowed by the Scala language, but is the set used elsewhere in this bundle for identifier matching.

Fixes #62 
  